### PR TITLE
Fix `conda-build` workaround for `<1.21.12`

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -102,9 +102,10 @@ def render_circle(jinja_env, forge_config, forge_dir):
 def fudge_subdir(subdir):
     # conda build <1.21.12 (no conda 4.2+)
     try:
-        import conda_build.metadata.cc as cc
+        import conda_build.metadata
+        cc = conda_build.metadata.cc
     # conda build 1.21.12+ (supports conda 4.2+)
-    except ImportError:
+    except AttributeError:
         import conda_build.metadata as cc
     orig = cc.subdir
     cc.subdir = subdir


### PR DESCRIPTION
As it seems `cc` is not a module, this import always failed before. So if we assign it, we get our fallback. This seems to work well for `conda-build <1.21.12`. As this is now an `AttributeError` if it is not found, we can handle that to get our fallback now. Tested this with `conda-smithy` versions `1.21.11`, `1.21.12`, and `1.21.14`.
